### PR TITLE
Minor bug fixes

### DIFF
--- a/fixtures/demo/import.st.css
+++ b/fixtures/demo/import.st.css
@@ -2,6 +2,10 @@
     -st-states: aState
 }
 
+.root {
+    -st-states: bState;
+}
+
 .gaga:aState {
     color:blue;
     mask: lala

--- a/fixtures/demo/test.css
+++ b/fixtures/demo/test.css
@@ -1,9 +1,7 @@
 .gaga {
-    -st-states: aState;
-  }
-  
-  .gaga:aState {
-    mask: lala; 
-    
-  }
-  
+  -st-states: aState;
+}
+
+.gaga:aState {
+  mask: lala;
+}

--- a/fixtures/demo/test.st.css
+++ b/fixtures/demo/test.st.css
@@ -1,4 +1,7 @@
-.local {
-    -st-states: artik, kartiv;
+:vars {
+    varvar: green;
 }
 
+.local {
+    color: rgb(value())
+}

--- a/fixtures/demo/test.st.css
+++ b/fixtures/demo/test.st.css
@@ -1,8 +1,4 @@
-:vars {
-    varvar: pink;
-    jarjar: red;
+.local {
+    -st-states: artik, kartiv;
 }
 
-.local {
-    color: value(varvar) value(jarjar)
-}

--- a/fixtures/server-cases/pseudo-elements/default-import-with-native-class.st.css
+++ b/fixtures/server-cases/pseudo-elements/default-import-with-native-class.st.css
@@ -7,4 +7,4 @@
     -st-extends: Comp;
 }
 
-.local::before::g
+.local:hover|

--- a/fixtures/server-cases/pseudo-elements/default-import-with-native-element.st.css
+++ b/fixtures/server-cases/pseudo-elements/default-import-with-native-element.st.css
@@ -7,4 +7,4 @@
     -st-extends: Comp;
 }
 
-.local::before::g
+.local::before|

--- a/src/lib/completion-providers.ts
+++ b/src/lib/completion-providers.ts
@@ -558,20 +558,26 @@ export const PseudoElementCompletionProvider: CompletionProvider = {
         let comps: any[] = [];
         if (!parentSelector && resolved.length > 0 && !isBetweenChars(fullLineText, position, '(', ')')) {
 
-            const lastNode = resolvedElements[0][resolvedElements[0].length - 1];
+            let lastNode = resolvedElements[0][resolvedElements[0].length - 1];
+            if (lastNode.type === 'pseudo-element' && nativePseudoElements.indexOf(lastNode.name) !== -1) {
+                lastNode = resolvedElements[0][resolvedElements[0].length - 2];
+            };
             const states = lastNode.resolved.reduce((acc, cur) => {
                 acc = acc.concat(keys((cur.symbol as ClassSymbol)[valueMapping.states]))
                 return acc;
             }, cssPseudoClasses)
 
             let filter = lastNode.resolved.length
-                ? ~states.indexOf(lastSelectoid.replace(':', ''))
+                ? states.indexOf(lastSelectoid.replace(':', '')) !== -1
                     ? ''
                     : lastSelectoid.replace(':', '')
                 : lastNode.name;
 
             const scope = filter
-                ? resolvedElements[0][resolvedElements[0].length - 2]
+                ? (resolvedElements[0][resolvedElements[0].length - 2].type==='pseudo-element'
+                    && nativePseudoElements.indexOf(resolvedElements[0][resolvedElements[0].length - 2].name)!==-1)
+                    ? resolvedElements[0][resolvedElements[0].length - 3]
+                    : resolvedElements[0][resolvedElements[0].length - 2]
                 : lastNode;
 
             const colons = lineChunkAtCursor.match(/:*$/)![0].length;

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -677,7 +677,6 @@ function findClassRefs(word: string, uri: string, fs: ExtendedFSReadSync): Locat
     })
     meta!.rawAst.walkDecls((decl) => {
         //Variable usage
-
         if (decl.value.includes('value(')) {
             const usageRegex = new RegExp('value\\(\\s*' + word + '\\s*\\)', 'g');
             const match = usageRegex.exec(decl.value);
@@ -694,7 +693,7 @@ function findClassRefs(word: string, uri: string, fs: ExtendedFSReadSync): Locat
                             character: match.index + decl.source.start!.column + decl.prop.length + (decl.raws.between ? decl.raws.between.length : 0) + 'value('.length + word.length - 1
                         }
                     }
-                })
+                });
             }
         }
     });

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -246,6 +246,9 @@ export default class Provider {
         } else if (line.slice(0, pos.character).trim().includes(':')) {
             value = line.slice(0, pos.character).trim().slice(line.slice(0, pos.character).trim().indexOf(':') + 1).trim();
         }
+        if (/value\(\s*[^\)]*$/.test(value)) {
+            return null;
+        }
         const parsed = pvp(value);
 
         let mixin = '';

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -113,6 +113,9 @@ export function initStylableLanguageService(connection: IConnection, services: {
         }
     });
 
+    connection.onDocumentFormatting((params) => {return null})
+
+
     connection.onDocumentColor((params: DocumentColorParams) => {
         const document = fs.get(params.textDocument.uri);
 

--- a/test/lib/completions/pseudo-elements.spec.ts
+++ b/test/lib/completions/pseudo-elements.spec.ts
@@ -1,6 +1,6 @@
 import * as asserters from './asserters';
 import { createRange, ProviderRange } from '../../../src/lib/completion-providers';
-import {Completion} from "../../../src/lib/completion-types";
+import { Completion } from "../../../src/lib/completion-types";
 
 describe('Pseudo-elements', function () {
 
@@ -440,4 +440,37 @@ describe('Pseudo-elements', function () {
         });
     });
 
+    describe('After CSS native elements', function () {
+
+        const str = '::momo';
+        const createCompletion = (str: string, rng: ProviderRange) => asserters.pseudoElementCompletion(str.slice(2), rng, './import.st.css');
+
+        str.split('').forEach((c, i) => {
+            let prefix = str.slice(0, i);
+
+            it('should complete pseudo-element ' + str + ' after CSS native pseudo-element with prefix: ' + prefix + ' ', function () {
+                let rng = createRange(9, 14, 9, 14 + i);
+
+                return asserters.getCompletions('pseudo-elements/default-import-with-native-element.st.css', prefix).then((asserter) => {
+                    let exp: Partial<Completion>[] = [];
+
+                    exp.push(createCompletion(str,rng))
+
+                    asserter.suggested(exp);
+                });
+            });
+
+            it('should complete pseudo-element ' + str + ' after CSS native pseudo-class with prefix: ' + prefix + ' ', function () {
+                let rng = createRange(9, 12, 9, 12 + i);
+
+                return asserters.getCompletions('pseudo-elements/default-import-with-native-class.st.css', prefix).then((asserter) => {
+                    let exp: Partial<Completion>[] = [];
+
+                    exp.push(createCompletion(str,rng))
+
+                    asserter.suggested(exp);
+                });
+            });
+        });
+    });
 });


### PR DESCRIPTION
Pseudo-elements and states are now properly completed after CSS native pseudo-elements and pseudo-classes. 
Fixed bug where writing value() inside a native CSS function caused signature help to throw an error. 
