### PR TITLE
upgrade stylable to the new scoped package

### DIFF
--- a/fixtures/server-cases/general/inside-simple-ruleset-with-all-st-fields.st.css
+++ b/fixtures/server-cases/general/inside-simple-ruleset-with-all-st-fields.st.css
@@ -2,6 +2,5 @@
     -st-states: a, b;
     -st-extends: Comp;
     -st-mixin: MixA;
-    -st-variant: BigButton;
     -|
 }

--- a/fixtures/server-cases/imports/inside-import-selector-with-fields.st.css
+++ b/fixtures/server-cases/imports/inside-import-selector-with-fields.st.css
@@ -3,6 +3,5 @@
     -st-from: "./import-from-here.st.css";
     -st-default: X;
     -st-named: shlomo;
-    -st-theme: true;
     -|
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:browser-compatible": "mocha --require ts-node/register test/browser-compatible.spec.ts"
   },
   "dependencies": {
+    "@stylable/core": "^0.1.7",
     "bignumber": "^1.1.0",
     "css-selector-tokenizer": "^0.7.0",
     "doctrine": "^2.1.0",
@@ -33,7 +34,6 @@
     "postcss": "^6.0.19",
     "postcss-selector-parser": "^4.0.0",
     "postcss-value-parser": "^3.3.0",
-    "stylable": "^5.4.10",
     "tslib": "^1.9.0",
     "typescript": "~2.8.3",
     "vscode": "^1.1.18",

--- a/spec/completions.md
+++ b/spec/completions.md
@@ -4,7 +4,7 @@ The provider provides completion suggestions when a user types a trigger charact
 
 Trigger charactes are:  "." ":" "-" and " "
 
-In the current examples '|' denotes the user's starting caret position. $1, $2, etc. denote tabstops inside the completion, with $0 being the final cursor position after completion. 
+In the current examples '|' denotes the user's starting caret position. $1, $2, etc. denote tabstops inside the completion, with $0 being the final cursor position after completion.
 
 ## Available Completions
 
@@ -45,13 +45,6 @@ Multiple use of the same directive in the same class is not allowed.
 ```css
     .gaga{
         -st-states:$1;
-    }$0
-```
-- -st-variant - defines the css class as a variant to be used as a mixin
-```css
-    .gaga{
-        -st-variant:true;
-        $1
     }$0
 ```
 

--- a/src/lib/completion-providers.ts
+++ b/src/lib/completion-providers.ts
@@ -12,7 +12,7 @@ import {
     VarSymbol,
     nativePseudoClasses,
     nativePseudoElements
-} from 'stylable';
+} from '@stylable/core';
 import { CursorPosition, SelectorChunk } from "./utils/selector-analyzer";
 import {
     classCompletion,
@@ -48,7 +48,7 @@ import {
 } from './provider';
 import { TypeReferenceNode } from 'typescript';
 import { toVscodePath } from './utils/uri-utils';
-import { ResolvedElement } from 'stylable/dist/src/stylable-transformer';
+import { ResolvedElement } from '@stylable/core/dist/src/stylable-transformer';
 import { find, keys, last } from 'lodash';
 import { ExtendedFSReadSync, ExtendedTsLanguageService } from './types';
 import { resolveStateTypeOrValidator } from './feature/pseudo-class';
@@ -162,8 +162,8 @@ function createDirectiveRange(position: ProviderPosition, fullLineText: string, 
     );
 }
 
-const importDeclarations: (keyof typeof importDirectives)[] = ['default', 'named', 'from', 'theme']
-const simpleRulesetDeclarations: (keyof typeof rulesetDirectives)[] = ['extends', 'states', 'variant', 'mixin']
+const importDeclarations: (keyof typeof importDirectives)[] = ['default', 'named', 'from']
+const simpleRulesetDeclarations: (keyof typeof rulesetDirectives)[] = ['extends', 'states', 'mixin']
 const topLevelDeclarations: (keyof typeof topLevelDirectives)[] = ['root', 'namespace', 'vars', 'import', 'customSelector']
 
 //Providers

--- a/src/lib/completion-types.ts
+++ b/src/lib/completion-types.ts
@@ -1,5 +1,5 @@
 import {ProviderRange} from './completion-providers';
-import {valueMapping} from 'stylable'
+import {valueMapping} from '@stylable/core'
 
 export class Completion {
     constructor(public label: string, public detail: string = "", public sortText: string = 'd', public insertText: string | snippet = label,
@@ -16,14 +16,12 @@ export const importDirectives = {
     from: valueMapping.from,
     default: valueMapping.default,
     named: valueMapping.named,
-    theme: valueMapping.theme
 }
 
 export const rulesetDirectives = {
     extends: valueMapping.extends,
     mixin: valueMapping.mixin,
     states: valueMapping.states,
-    variant: valueMapping.variant
 }
 
 export const topLevelDirectives = {
@@ -44,8 +42,6 @@ export function importInternalDirective(type: keyof typeof importDirectives, rng
             return new Completion(valueMapping.from + ':', 'Path to library', 'a', new snippet(valueMapping.from + ': "$1";'), rng);
         case valueMapping.named:
             return new Completion(valueMapping.named + ':', 'Named export name', 'a', new snippet(valueMapping.named + ': $1;'), rng);
-        case valueMapping.theme:
-            return new Completion(valueMapping.theme + ':', 'Declare a theme', 'a', new snippet(valueMapping.theme + ': true;\n$0'), rng);
     }
 }
 
@@ -57,8 +53,6 @@ export function rulesetInternalDirective(type: keyof typeof rulesetDirectives, r
             return new Completion(valueMapping.mixin + ':', 'Apply mixins on the class', 'a', new snippet('-st-mixin: $1;'), rng, true);
         case valueMapping.states:
             return new Completion(valueMapping.states + ':', 'Define the CSS states available for this class', 'a', new snippet('-st-states: $1;'), rng);
-        case valueMapping.variant:
-            return new Completion(valueMapping.variant + ':', 'Is a variant', 'a', new snippet('-st-variant: true;'), rng);
     }
 }
 

--- a/src/lib/diagnosis.ts
+++ b/src/lib/diagnosis.ts
@@ -1,8 +1,8 @@
-import {StylableMeta} from 'stylable/dist/src/stylable-processor';
+import {StylableMeta} from '@stylable/core/dist/src/stylable-processor';
 import {Diagnostic, Range, TextDocument} from 'vscode-languageserver-types';
 import * as path from 'path';
-import {Diagnostics, FileProcessor, process as stylableProcess, safeParse, StylableTransformer} from 'stylable';
-import {Diagnostic as Report} from 'stylable/src/diagnostics'
+import {Diagnostics, FileProcessor, process as stylableProcess, safeParse, StylableTransformer} from '@stylable/core';
+import {Diagnostic as Report} from '@stylable/core/src/diagnostics'
 import {FileSystemReadSync} from 'kissfs';
 import {fromVscodePath} from './utils/uri-utils';
 

--- a/src/lib/feature/color-provider.ts
+++ b/src/lib/feature/color-provider.ts
@@ -1,7 +1,7 @@
 import { ColorPresentationParams, TextDocument } from 'vscode-languageserver-protocol';
 import { ProviderPosition, ProviderRange } from '../completion-providers';
 import { Color, ColorPresentation, ColorInformation } from 'vscode-css-languageservice';
-import { evalDeclarationValue, valueMapping, Stylable, StylableMeta } from 'stylable';
+import { evalDeclarationValue, valueMapping, Stylable, StylableMeta } from '@stylable/core';
 import { CssService } from '../../model/css-service';
 import { fixAndProcess } from '../provider';
 import { last } from 'lodash';

--- a/src/lib/feature/pseudo-class.ts
+++ b/src/lib/feature/pseudo-class.ts
@@ -1,4 +1,4 @@
-import { StylableMeta, ParsedValue, systemValidators, StateParsedValue } from 'stylable';
+import { StylableMeta, ParsedValue, systemValidators, StateParsedValue } from '@stylable/core';
 import { ProviderPosition } from '../completion-providers';
 import {
     ParameterInformation,

--- a/src/lib/provider-factory.ts
+++ b/src/lib/provider-factory.ts
@@ -1,6 +1,6 @@
 'use strict';
 import { FileSystemReadSync } from 'kissfs';
-import { Stylable } from 'stylable';
+import { Stylable } from '@stylable/core';
 import { Event, TextDocument, TextDocumentChangeEvent, TextDocuments } from 'vscode-languageserver';
 import Provider from './provider';
 import { ExtendedTsLanguageService } from './types';

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -14,7 +14,7 @@ import {
     StylableMeta,
     StylableTransformer,
     valueMapping
-} from 'stylable';
+} from '@stylable/core';
 import { isContainer, isDeclaration, isRoot, isSelector, pathFromPosition } from './utils/postcss-ast-utils';
 import {
     CodeMixinCompletionProvider,
@@ -54,7 +54,7 @@ import { ParameterDeclaration, SignatureDeclaration, TypeReferenceNode } from 't
 import { fromVscodePath, toVscodePath } from './utils/uri-utils';
 import { keys, last, values } from 'lodash';
 import { ExtendedFSReadSync, ExtendedTsLanguageService } from './types';
-import { ClassSymbol, StylableSymbol, ElementSymbol } from 'stylable/dist/src/stylable-processor';
+import { ClassSymbol, StylableSymbol, ElementSymbol } from '@stylable/core/dist/src/stylable-processor';
 import {
     createStateTypeSignature,
     createStateValidatorSignature,

--- a/src/lib/server-utils.ts
+++ b/src/lib/server-utils.ts
@@ -5,7 +5,7 @@ import {createFs, MinimalDocs,} from './provider-factory';
 import {ColorPresentationRequest, DocumentColorRequest} from 'vscode-languageserver-protocol';
 import {fromVscodePath, toVscodePath} from './utils/uri-utils';
 import {initStylableLanguageService} from './service'
-import {Stylable} from 'stylable';
+import {Stylable} from '@stylable/core';
 import *  as ts from 'typescript';
 import {FileSystemReadSync} from 'kissfs';
 import {ExtendedFSReadSync, ExtendedTsLanguageService} from './types';

--- a/src/lib/service.ts
+++ b/src/lib/service.ts
@@ -14,7 +14,7 @@ import { ProviderPosition, ProviderRange } from './completion-providers';
 import { Completion } from './completion-types';
 import { createDiagnosis } from './diagnosis';
 import { Command, CompletionItem, Location, ParameterInformation, TextEdit, Diagnostic } from 'vscode-languageserver-types';
-import { Stylable } from 'stylable';
+import { Stylable } from '@stylable/core';
 import { fromVscodePath, toVscodePath } from './utils/uri-utils';
 import { getRefs, getDefSymbol, getRenameRefs } from './provider';
 import { ExtendedFSReadSync, ExtendedTsLanguageService, NotificationTypes } from './types'

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,7 +16,7 @@ import {
 } from 'vscode-languageserver-protocol';
 import {FileSystemReadSync} from 'kissfs';
 import * as ts from 'typescript';
-import {ParsedValue} from 'stylable';
+import {ParsedValue} from '@stylable/core';
 
 export interface NotificationTypes {
     openDoc: NotificationType<string, void>;

--- a/syntaxes/stylable.tmLanguage.json
+++ b/syntaxes/stylable.tmLanguage.json
@@ -1380,7 +1380,7 @@
           "name": "variable.css"
         },
         {
-          "match": "-st-states|-st-extends|-st-compose|-st-mixin|-st-from|-st-default|-st-named|-st-theme|-st-global",
+          "match": "-st-states|-st-extends|-st-mixin|-st-from|-st-default|-st-named|-st-global",
           "name": "keyword.other.directive.stylable"
         },
         {

--- a/test-kit/asserters.ts
+++ b/test-kit/asserters.ts
@@ -2,7 +2,7 @@ import * as ts from 'typescript';
 import * as fs from 'fs';
 import * as path from 'path';
 import { NodeBase } from 'postcss';
-import { Stylable } from 'stylable';
+import { Stylable } from '@stylable/core';
 import { TextDocument, TextDocumentIdentifier, Range } from 'vscode-languageserver-types';
 import { Location, ParameterInformation, SignatureHelp, ColorPresentation, Color } from 'vscode-languageserver';
 import { ColorInformation } from 'vscode-css-languageservice';

--- a/test/lib/completions/asserters.ts
+++ b/test/lib/completions/asserters.ts
@@ -8,7 +8,7 @@ import {Completion, snippet} from '../../../src/lib/completion-types';
 import {ProviderPosition, ProviderRange} from '../../../src/lib/completion-providers';
 import {default as Provider} from '../../../src/lib/provider';
 import {fromVscodePath} from '../../../src/lib/utils/uri-utils';
-import {Stylable} from 'stylable';
+import {Stylable} from '@stylable/core';
 import {LocalSyncFs} from '../../../src/lib/local-sync-fs';
 import {createDocFs} from '../../../src/lib/server-utils';
 import {createBaseHost, createLanguageServiceHost} from '../../../src/lib/utils/temp-language-service-host';
@@ -186,15 +186,6 @@ export const statesDirectiveCompletion: (rng: ProviderRange) => Partial<Completi
         range: rng
     };
 }
-export const themeDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
-    return {
-        label: '-st-theme:',
-        detail: 'Declare a theme',
-        sortText: 'a',
-        insertText: '-st-theme: true;\n$0',
-        range: rng
-    };
-}
 export const valueDirective: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
         label: 'value()',
@@ -206,9 +197,6 @@ export const valueDirective: (rng: ProviderRange) => Partial<Completion> = (rng)
 }
 export const varsDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {label: ':vars', detail: 'Declare variables', sortText: 'a', insertText: ':vars {\n\t$1\n}$0', range: rng};
-}
-export const variantDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
-    return {label: '-st-variant:', detail: 'Is a variant', sortText: 'a', insertText: '-st-variant: true;', range: rng};
 }
 export const globalCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return new Completion(':global()', 'Target a global selector', 'a', ':global($0)', rng)

--- a/test/lib/completions/completion.spec.ts
+++ b/test/lib/completions/completion.spec.ts
@@ -18,7 +18,6 @@ describe('Completions', function () {
                     asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
-                    asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0))
                 ]);
             });
         });
@@ -37,7 +36,6 @@ describe('Completions', function () {
                     asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
-                    asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0)),
                 ]);
             });
         });
@@ -53,7 +51,6 @@ describe('Completions', function () {
                     asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
-                    asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0)),
                 ])
             });
         });
@@ -71,7 +68,6 @@ describe('Completions', function () {
                     asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
-                    asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0)),
                 ])
             });
         });

--- a/test/lib/completions/st-directives.spec.ts
+++ b/test/lib/completions/st-directives.spec.ts
@@ -44,37 +44,22 @@ describe('Inner Directives', function () {
         });
     });
 
-    describe('should complete -st-theme inside import selector ', function () {
-        importDirectives.theme.split('').map((c, i) => {
-            let prefix = importDirectives.theme.slice(0, i);
-            it(' with Prefix: ' + prefix + ' ', function () {
-                return asserters.getCompletions('imports/inside-import-selector.st.css', prefix).then((asserter) => {
-                    asserter.suggested([
-                        asserters.themeDirectiveCompletion(createRange(2, 4, 2, 4 + i))
-                    ]);
-                });
-            });
-        });
-    });
-
-    it('should not complete -st-from, -st-default, -st-named, -st-theme inside import directives when exists', function () {
+    it('should not complete -st-from, -st-default, -st-named inside import directives when exists', function () {
         return asserters.getCompletions('imports/inside-import-selector-with-fields.st.css').then((asserter) => {
             asserter.notSuggested([
                 asserters.importFromDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.importDefaultDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.importNamedDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.themeDirectiveCompletion(createRange(0, 0, 0, 0)),
             ]);
         });
     });
 
-    it('should not complete -st-from, -st-default, -st-named, -st-theme outisde the import ruleset', function () {
+    it('should not complete -st-from, -st-default, -st-named outisde the import ruleset', function () {
         return asserters.getCompletions('imports/outside-ruleset.st.css').then((asserter) => {
             asserter.notSuggested([
                 asserters.importFromDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.importDefaultDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.importNamedDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.themeDirectiveCompletion(createRange(0, 0, 0, 0)),
             ]);
         });
     });
@@ -118,31 +103,17 @@ describe('Inner Directives', function () {
         });
     });
 
-    describe('should complete -st-variant inside simple selector ruleset ', function () {
-        rulesetDirectives.variant.split('').map((c, i) => {
-            let prefix = rulesetDirectives.variant.slice(0, i);
-            it(' with Prefix: ' + prefix + ' ', function () {
-                return asserters.getCompletions('imports/inside-ruleset.st.css', prefix).then((asserter) => {
-                    asserter.suggested([
-                        asserters.variantDirectiveCompletion(createRange(2, 4, 2, 4 + i))
-                    ]);
-                });
-            });
-        });
-    });
-
-    it('should not complete -st-states, -st-extends, -st-mixin, -st-variant inside simple selector ruleset when they exist', function () {
+    it('should not complete -st-states, -st-extends, -st-mixin inside simple selector ruleset when they exist', function () {
         return asserters.getCompletions('general/inside-simple-ruleset-with-all-st-fields.st.css').then((asserter) => {
             asserter.notSuggested([
                 asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0)),
             ]);
         });
     });
 
-    it('should complete -st-mixin, but not -st-states, -st-extends, -st-variant inside media query', function () {
+    it('should complete -st-mixin, but not -st-states, -st-extends inside media query', function () {
         return asserters.getCompletions('complex-selectors/media-query.st.css').then((asserter) => {
             asserter.suggested([
                 asserters.mixinDirectiveCompletion(createRange(2, 8, 2, 8)),
@@ -150,12 +121,11 @@ describe('Inner Directives', function () {
             asserter.notSuggested([
                 asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                 asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
-                asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0)),
             ]);
         });
     });
 
-    describe('should complete -st-mixin, but not -st-states, -st-extends, -st-variant inside complex rules', function () {
+    describe('should complete -st-mixin, but not -st-states, -st-extends inside complex rules', function () {
         [
             'complex-selectors/class-and-class.st.css',
             'complex-selectors/class-and-descendant.st.css',
@@ -171,7 +141,6 @@ describe('Inner Directives', function () {
                     asserter.notSuggested([
                         asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                         asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
-                        asserters.variantDirectiveCompletion(createRange(0, 0, 0, 0)),
                     ]);
                 });
             })

--- a/test/lib/diagnostics.spec.ts
+++ b/test/lib/diagnostics.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai'
-import { Stylable } from 'stylable';
+import { Stylable } from '@stylable/core';
 import { MemoryFileSystem } from 'kissfs';
 import { TextDocument } from 'vscode-languageserver-types'
 import { TextDocuments } from "vscode-languageserver";

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,6 +8,25 @@
   dependencies:
     samsam "1.3.0"
 
+"@stylable/core@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@stylable/core/-/core-0.1.7.tgz#a99f38fa4e5bede9b516b2e6c74533b84ed5fa52"
+  dependencies:
+    clean-css "^4.1.11"
+    css-selector-tokenizer "^0.7.0"
+    deindent "^0.1.0"
+    enhanced-resolve "^4.0.0"
+    is-vendor-prefixed "^1.0.0"
+    lodash.clonedeep "^4.5.0"
+    murmurhash "^0.0.2"
+    postcss "^6.0.23"
+    postcss-js "^1.0.1"
+    postcss-nested "^3.0.0"
+    postcss-safe-parser "^3.0.1"
+    postcss-selector-matches "^3.0.1"
+    postcss-value-parser "^3.3.0"
+    url-regex "^4.1.1"
+
 "@types/autobahn@^0.9.38":
   version "0.9.39"
   resolved "https://registry.yarnpkg.com/@types/autobahn/-/autobahn-0.9.39.tgz#005fa7d8375bde71f1fd401d73958b640e6b8963"
@@ -4261,25 +4280,6 @@ strip-bom@^3.0.0:
 strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-
-stylable@^5.4.10:
-  version "5.4.11"
-  resolved "https://registry.yarnpkg.com/stylable/-/stylable-5.4.11.tgz#a54fbd0cad902b5f98f3d01227b63527a6a9a4d7"
-  dependencies:
-    clean-css "^4.1.11"
-    css-selector-tokenizer "^0.7.0"
-    deindent "^0.1.0"
-    enhanced-resolve "^4.0.0"
-    is-vendor-prefixed "^1.0.0"
-    lodash.clonedeep "^4.5.0"
-    murmurhash "^0.0.2"
-    postcss "^6.0.23"
-    postcss-js "^1.0.1"
-    postcss-nested "^3.0.0"
-    postcss-safe-parser "^3.0.1"
-    postcss-selector-matches "^3.0.1"
-    postcss-value-parser "^3.3.0"
-    url-regex "^4.1.1"
 
 style-loader@^0.19.1:
   version "0.19.1"


### PR DESCRIPTION
Also, remove deprecated handling for `-st-variant` and `-st-theme`