### PR TITLE
@st-scope

### DIFF
--- a/fixtures/demo/scoping.st.css
+++ b/fixtures/demo/scoping.st.css
@@ -1,0 +1,10 @@
+
+@st-scope .g {
+    asdf {
+        color: red;         
+    }
+}
+
+.blah {
+    color: green;
+}

--- a/src/lib/completion-providers.ts
+++ b/src/lib/completion-providers.ts
@@ -165,7 +165,7 @@ function createDirectiveRange(position: ProviderPosition, fullLineText: string, 
 
 const importDeclarations: (keyof typeof importDirectives)[] = ['default', 'named', 'from']
 const simpleRulesetDeclarations: (keyof typeof rulesetDirectives)[] = ['extends', 'states', 'mixin']
-const topLevelDeclarations: (keyof typeof topLevelDirectives)[] = ['root', 'namespace', 'vars', 'import', 'customSelector']
+const topLevelDeclarations: (keyof typeof topLevelDirectives)[] = ['root', 'namespace', 'vars', 'import', 'customSelector', 'stScope']
 
 //Providers
 //Syntactic

--- a/src/lib/completion-types.ts
+++ b/src/lib/completion-types.ts
@@ -29,7 +29,8 @@ export const topLevelDirectives = {
     namespace: '@namespace' as '@namespace',
     customSelector: '@custom-selector :--' as '@custom-selector :--',
     vars: ':vars' as ':vars',
-    import: ':import' as ':import'
+    import: ':import' as ':import',
+    stScope: '@st-scope' as '@st-scope'
 }
 
 //syntactic
@@ -68,6 +69,8 @@ export function topLevelDirective(type: keyof typeof topLevelDirectives, rng: Pr
             return new Completion(topLevelDirectives.root, 'The root class', 'a', undefined, rng);
         case topLevelDirectives.vars:
             return new Completion(topLevelDirectives.vars, 'Declare variables', 'a', new snippet(':vars {\n\t$1\n}$0'), rng);
+        case topLevelDirectives.stScope:
+            return new Completion(topLevelDirectives.stScope, 'Define an @st-scope', 'a', new snippet('@st-scope $1 {\n\t$2\n}$0'), rng);
     }
 }
 

--- a/src/lib/provider.ts
+++ b/src/lib/provider.ts
@@ -216,26 +216,30 @@ export default class Provider {
             return null
         }
 
-        if ((meta.mappedSymbols[mixin]! as ImportSymbol).import.from.endsWith('.ts')) {
-            return this.getSignatureForTsModifier(mixin, activeParam, (meta.mappedSymbols[mixin]! as ImportSymbol).import.from, (meta.mappedSymbols[mixin]! as ImportSymbol).type === 'default', paramInfo);
-        } else if ((meta.mappedSymbols[mixin]! as ImportSymbol).import.from.endsWith('.js')) {
-            if (fs.getOpenedFiles().indexOf(toVscodePath((meta.mappedSymbols[mixin]! as ImportSymbol).import.from.slice(0, -3) + '.d.ts')) !== -1) {
-                return this.getSignatureForTsModifier(mixin, activeParam, (meta.mappedSymbols[mixin]! as ImportSymbol).import.from.slice(0, -3) + '.d.ts', (meta.mappedSymbols[mixin]! as ImportSymbol).type === 'default', paramInfo);
-            } else {
-                const importPath = (meta.mappedSymbols[mixin]! as ImportSymbol).import.from;
-                const feh = this.styl.resolvePath(undefined, importPath);
+        const mappedSymbol = meta.mappedSymbols[mixin];
 
-                return this.getSignatureForJsModifier(
-                    mixin,
-                    activeParam,
-                    // fs.get(this.resolveImport((meta.mappedSymbols[mixin]! as ImportSymbol).import.from, this.styl, meta)!.source).getText(),
-                    fs.get(feh).getText(),
-                    paramInfo
-                )
-            }
-        } else {
-            return null;
-        }
+        if (mappedSymbol && mappedSymbol._kind === 'import') {
+            if (mappedSymbol.import.from.endsWith('.ts')) {
+                return this.getSignatureForTsModifier(mixin, activeParam, (mappedSymbol as ImportSymbol).import.from, (meta.mappedSymbols[mixin]! as ImportSymbol).type === 'default', paramInfo);
+            } else if (mappedSymbol.import.from.endsWith('.js')) {
+                if (fs.getOpenedFiles().indexOf(toVscodePath(mappedSymbol.import.from.slice(0, -3) + '.d.ts')) !== -1) {
+                    return this.getSignatureForTsModifier(mixin, activeParam, mappedSymbol.import.from.slice(0, -3) + '.d.ts', mappedSymbol.type === 'default', paramInfo);
+                } else {
+                    const importPath = mappedSymbol.import.from;
+                    const feh = this.styl.resolvePath(undefined, importPath);
+    
+                    return this.getSignatureForJsModifier(
+                        mixin,
+                        activeParam,
+                        // fs.get(this.resolveImport(mappedSymbol.import.from, this.styl, meta)!.source).getText(),
+                        fs.get(feh).getText(),
+                        paramInfo
+                    )
+                }
+            }    
+        } 
+            
+        return null;
     }
 
     private findWord(word: string, src: string, position: Position): ProviderRange {

--- a/src/model/css-service.ts
+++ b/src/model/css-service.ts
@@ -63,7 +63,10 @@ export class CssService {
                 if (diag.code === 'emptyRules') {
                     return false;
                 }
-                if (diag.code === 'css-unknownatrule' && readDocRange(document, diag.range) === '@custom-selector') {
+                if (diag.code === 'unknownAtRules' && readDocRange(document, diag.range) === '@custom-selector') {
+                    return false;
+                }
+                if (diag.code === 'unknownAtRules' && readDocRange(document, diag.range) === '@st-scope') {
                     return false;
                 }
                 if (diag.code === 'css-lcurlyexpected' && readDocRange(document, Range.create(Position.create(diag.range.start.line, 0), diag.range.end)).startsWith('@custom-selector')) {

--- a/test/lib/completions/asserters.ts
+++ b/test/lib/completions/asserters.ts
@@ -121,6 +121,15 @@ export const customSelectorDirectiveCompletion: (rng: ProviderRange) => Partial<
         range: rng
     };
 }
+export const stScopeDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
+    return {
+        label: '@st-scope',
+        detail: 'Define an @st-scope',
+        sortText: 'a',
+        insertText: '@st-scope $1 {\n\t$2\n}$0',
+        range: rng
+    };
+}
 export const extendsDirectiveCompletion: (rng: ProviderRange) => Partial<Completion> = (rng) => {
     return {
         label: '-st-extends:',

--- a/test/lib/completions/completion.spec.ts
+++ b/test/lib/completions/completion.spec.ts
@@ -1,15 +1,17 @@
 import * as asserters from './asserters';
 import { createRange } from '../../../src/lib/completion-providers';
 
-describe('Completions', function () {
+describe.only('Completions', function () {
     describe('Stylesheet Top Level', function () {
         it('should complete ONLY import and vars directive, root and existing classes at top level', function () {
             return asserters.getCompletions('general/top-level-existing-classes.st.css').then((asserter) => {
                 asserter.suggested(
                     [
                         asserters.importDirectiveCompletion(createRange(3, 0, 3, 0)),
-                        asserters.rootClassCompletion(createRange(3, 0, 3, 0)),
+                        asserters.customSelectorDirectiveCompletion(createRange(3, 0, 3, 0)),
+                        asserters.stScopeDirectiveCompletion(createRange(3, 0, 3, 0)),
                         asserters.varsDirectiveCompletion(createRange(3, 0, 3, 0)),
+                        asserters.rootClassCompletion(createRange(3, 0, 3, 0)),
                         asserters.classCompletion('gaga', (createRange(3, 0, 3, 0))),
                         asserters.classCompletion('baga', (createRange(3, 0, 3, 0))),
                     ]
@@ -27,6 +29,9 @@ describe('Completions', function () {
                 asserter.suggested(
                     [
                         asserters.importDirectiveCompletion(createRange(3, 0, 3, 0)),
+                        asserters.customSelectorDirectiveCompletion(createRange(3, 0, 3, 0)),
+                        asserters.stScopeDirectiveCompletion(createRange(3, 0, 3, 0)),
+                        asserters.varsDirectiveCompletion(createRange(3, 0, 3, 0)),
                         asserters.rootClassCompletion(createRange(3, 0, 3, 0)),
                         asserters.classCompletion('gaga', (createRange(3, 0, 3, 0))),
                     ]
@@ -51,6 +56,9 @@ describe('Completions', function () {
                     asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.extendsDirectiveCompletion(createRange(0, 0, 0, 0)),
                     asserters.mixinDirectiveCompletion(createRange(0, 0, 0, 0)),
+                    asserters.customSelectorDirectiveCompletion(createRange(0, 0, 0, 0)),
+                    asserters.stScopeDirectiveCompletion(createRange(0, 0, 0, 0)),
+                    asserters.varsDirectiveCompletion(createRange(0, 0, 0, 0)),
                 ])
             });
         });
@@ -63,6 +71,8 @@ describe('Completions', function () {
                     asserters.varsDirectiveCompletion((createRange(9, 0, 9, 0))),
                     asserters.importDirectiveCompletion(createRange(9, 0, 9, 0)),
                     asserters.namespaceDirectiveCompletion(createRange(9, 0, 9, 0)),
+                    asserters.customSelectorDirectiveCompletion(createRange(9, 0, 9, 0)),
+                    asserters.stScopeDirectiveCompletion(createRange(9, 0, 9, 0)),
                 ]);
                 asserter.notSuggested([
                     asserters.statesDirectiveCompletion(createRange(0, 0, 0, 0)),
@@ -83,6 +93,10 @@ describe('Completions', function () {
                 );
                 asserter.notSuggested([
                     asserters.rootClassCompletion(createRange(0, 0, 0, 0)),
+                    asserters.customSelectorDirectiveCompletion(createRange(0, 0, 0, 0)),
+                    asserters.stScopeDirectiveCompletion(createRange(0, 0, 0, 0)),
+                    asserters.varsDirectiveCompletion(createRange(0, 0, 0, 0)),
+                    
                 ]);
             });
         });

--- a/test/lib/completions/completion.spec.ts
+++ b/test/lib/completions/completion.spec.ts
@@ -1,7 +1,7 @@
 import * as asserters from './asserters';
 import { createRange } from '../../../src/lib/completion-providers';
 
-describe.only('Completions', function () {
+describe('Completions', function () {
     describe('Stylesheet Top Level', function () {
         it('should complete ONLY import and vars directive, root and existing classes at top level', function () {
             return asserters.getCompletions('general/top-level-existing-classes.st.css').then((asserter) => {


### PR DESCRIPTION
Add language services for new `@st-scope` feature from Stylable.

Currently working:
- [x] root level completion for `@st-scope` directive
- [x] `go to symbol`
    - `@st-scope` param selector symbol
    - nested rules (including pseudo-elements) 
    - variable usage symbol (inside `value()`)
- [x] `find references`
    - `@st-scope` param selector symbol
    - nested rules (including pseudo-elements) 
    - variable usage symbol (inside `value()`)
- [x] `rename symbol`
    - `@st-scope` param selector symbol
    - nested rules (including pseudo-elements) 
    - variable usage symbol (inside `value()`)
- [x] nested rules completions 
- [x] `value()` completion in nested declarations

Missing capabilities:
- [ ] completion for scoping parameter
- [ ] native and Stylable completions for declarations inside scoped rules
- [ ] CSS colors
- [ ] add diagnostics for nested `@custom-selector`, `@st-scope` and `@namespace` (in `@stylable/core`)
- [ ] `go to definition` for states in nested rules
- [ ] `find references` 
    - states in nested rules
    - `@st-scope` param not included in searches
- [ ] `find references` 
