### PR TITLE
config(CI): enable AppVeyor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: node_js
 os:
   - linux
   - osx
-  - windows
 
 node_js:
   - 12 # lts, and the version vscode-stable currently uses (via electron)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # stylable-intelligence
 [![Visual Studio Marketplace](https://img.shields.io/vscode-marketplace/v/wix.stylable-intelligence.svg)](https://marketplace.visualstudio.com/items?itemName=wix.stylable-intelligence)
 [![Build Status](https://travis-ci.com/wix/stylable-intelligence.svg?branch=master)](https://travis-ci.com/wix/stylable-intelligence)
+[![Build status](https://ci.appveyor.com/api/projects/status/7dk4trpid93fa56b/branch/master?svg=true)](https://ci.appveyor.com/project/AlexShemeshWix/stylable-intelligence/branch/master)
 [![Visual Studio Marketplace](https://img.shields.io/vscode-marketplace/d/wix.stylable-intelligence.svg)](https://marketplace.visualstudio.com/items?itemName=wix.stylable-intelligence)
 [![npm version](https://badge.fury.io/js/stylable-intelligence.svg)](https://badge.fury.io/js/stylable-intelligence)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+environment:
+  nodejs_version: "12"
+
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - yarn
+
+test_script:
+  - node --version
+  - yarn --version
+  # run tests
+  - yarn test
+
+build: off
+
+cache:
+  - "%LOCALAPPDATA%\\Yarn"


### PR DESCRIPTION
- disabled Travis Windows container. it's missing .dll files to run vscode@1.42.0. works on AppVeyor.
- added AppVeyor badge to README