### PR TITLE
infra: fix CI warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,12 @@ os:
 node_js:
   - 12 # lts, and the version vscode-stable currently uses (via electron)
 
+addons:
+  apt:
+    packages:
+    # resolves a warning while running e2e. needed by electron (used by node-keytar).
+    - libsecret-1-dev
+
 # Travis uses older yarn on linux, and yarn@latest on other platforms.
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.22.4

--- a/test/e2e/index.ts
+++ b/test/e2e/index.ts
@@ -8,16 +8,16 @@ const testsRoot = __dirname;
 
 export async function run() {
     const mocha = new Mocha({
-        ui: 'tdd'
+        ui: 'tdd',
+        color: true,
     });
-    mocha.useColors(true);
     const testFilePaths = await glob('**/**.test.js', { cwd: testsRoot, absolute: true });
     for (const filePath of testFilePaths) {
         mocha.addFile(normalize(filePath));
     }
     await new Promise((resolve, reject) => {
         try {
-            mocha.run(failures => {
+            mocha.run((failures) => {
                 if (failures > 0) {
                     reject(new Error(`${failures} tests failed.`));
                 } else {


### PR DESCRIPTION
- fix: install `libsecret` to resolve warnings while running e2e. needed by `electron` (used by `node-keytar`).
- fix: warnings regarding `useColors` being deprecated.

ref: https://travis-ci.com/github/wix/stylable-intelligence/jobs/317455468#L359