### PR TITLE
chore: migrate to @vscode/test-electron from vscode-test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/vscode": "1.57.0",
         "@typescript-eslint/eslint-plugin": "^5.19.0",
         "@typescript-eslint/parser": "^5.19.0",
+        "@vscode/test-electron": "^2.1.3",
         "chai": "^4.3.6",
         "eslint": "^8.13.0",
         "eslint-config-prettier": "^8.5.0",
@@ -40,8 +41,7 @@
         "mocha": "^9.2.2",
         "rimraf": "^3.0.2",
         "sinon": "^13.0.2",
-        "vsce": "^2.7.0",
-        "vscode-test": "^1.6.1"
+        "vsce": "^2.7.0"
       },
       "engines": {
         "vscode": "^1.57.0"
@@ -604,6 +604,21 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "node_modules/@vscode/test-electron": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
+      "integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+      "dev": true,
+      "dependencies": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      },
+      "engines": {
+        "node": ">=8.9.3"
+      }
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -4348,22 +4363,6 @@
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
       "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
     },
-    "node_modules/vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "deprecated": "This package has been renamed to @vscode/test-electron, please update to the new name",
-      "dev": true,
-      "dependencies": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      },
-      "engines": {
-        "node": ">=8.9.3"
-      }
-    },
     "node_modules/vscode-uri": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
@@ -5008,6 +5007,18 @@
       "resolved": "https://registry.npmjs.org/@ungap/promise-all-settled/-/promise-all-settled-1.1.2.tgz",
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
+    },
+    "@vscode/test-electron": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.1.3.tgz",
+      "integrity": "sha512-ps/yJ/9ToUZtR1dHfWi1mDXtep1VoyyrmGKC3UnIbScToRQvbUjyy1VMqnMEW3EpMmC3g7+pyThIPtPyCLHyow==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -7839,18 +7850,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vscode-nls/-/vscode-nls-5.0.0.tgz",
       "integrity": "sha512-u0Lw+IYlgbEJFF6/qAqG2d1jQmJl0eyAGJHoAJqr2HT4M2BNuQYSEiSE75f52pXHSJm8AlTjnLLbBFPrdz2hpA=="
-    },
-    "vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      }
     },
     "vscode-uri": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/vscode": "1.57.0",
     "@typescript-eslint/eslint-plugin": "^5.19.0",
     "@typescript-eslint/parser": "^5.19.0",
+    "@vscode/test-electron": "^2.1.3",
     "chai": "^4.3.6",
     "eslint": "^8.13.0",
     "eslint-config-prettier": "^8.5.0",
@@ -54,8 +55,7 @@
     "mocha": "^9.2.2",
     "rimraf": "^3.0.2",
     "sinon": "^13.0.2",
-    "vsce": "^2.7.0",
-    "vscode-test": "^1.6.1"
+    "vsce": "^2.7.0"
   },
   "author": "Tom Raviv",
   "publisher": "wix",

--- a/run-e2e-tests.js
+++ b/run-e2e-tests.js
@@ -1,12 +1,22 @@
 const path = require('path');
-const { runTests } = require('vscode-test');
+const { runTests } = require('@vscode/test-electron');
 
-// Download VS Code, unzip it and run the integration test
-runTests({
-    extensionDevelopmentPath: __dirname,
-    extensionTestsPath: path.join(__dirname, 'dist/test/e2e'),
-    launchArgs: ['--disable-extensions', path.join(__dirname, 'fixtures/e2e-cases')],
-}).catch((e) => {
-    console.error('Test Failed', e);
-    process.exit(1);
-});
+async function main() {
+    try {
+        // The folder containing the Extension Manifest package.json
+        // Passed to `--extensionDevelopmentPath`
+        const extensionDevelopmentPath = __dirname;
+
+        // The path to the extension test script
+        // Passed to --extensionTestsPath
+        const extensionTestsPath = path.join(__dirname, './dist/test/e2e/index');
+
+        // Download VS Code, unzip it and run the integration test
+        await runTests({ extensionDevelopmentPath, extensionTestsPath });
+    } catch (err) {
+        console.error('Failed to run tests');
+        process.exit(1);
+    }
+}
+
+main();


### PR DESCRIPTION
Following migration instruction from here: https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode